### PR TITLE
add handling canceled subscriptions

### DIFF
--- a/app/(auth)/lib/is-route06-user.ts
+++ b/app/(auth)/lib/is-route06-user.ts
@@ -1,8 +1,7 @@
 "use server";
 
 import { getUser } from "@/lib/supabase";
-
-const R06_EMAIL_DOMAIN = "route06.co.jp";
+import { isEmailFromRoute06 } from "@/lib/utils";
 
 export const isRoute06User = async () => {
 	const supabaseUser = await getUser();
@@ -12,6 +11,5 @@ export const isRoute06User = async () => {
 		throw new Error("No email found for user");
 	}
 
-	const emailDomain = email.split("@")[1];
-	return emailDomain === R06_EMAIL_DOMAIN;
+	return isEmailFromRoute06(email);
 };

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,4 @@
-import { retrieveStripeSubscriptionBySupabaseUserId } from "@/services/accounts/actions";
+import { retrieveActiveStripeSubscriptionBySupabaseUserId } from "@/services/accounts/actions";
 import { NextResponse } from "next/server";
 import { supabaseMiddleware } from "./lib/supabase";
 import { isEmailFromRoute06 } from "./lib/utils";
@@ -13,7 +13,7 @@ export default supabaseMiddleware(async (user, request) => {
 
 	// Proceeding to check the user's subscription status since the email is not from the route06.co.jp
 	if (!isEmailFromRoute06(user.email ?? "")) {
-		const subscription = await retrieveStripeSubscriptionBySupabaseUserId(
+		const subscription = await retrieveActiveStripeSubscriptionBySupabaseUserId(
 			user.id,
 		);
 		if (subscription == null) {

--- a/services/accounts/actions.ts
+++ b/services/accounts/actions.ts
@@ -1,1 +1,1 @@
-export { retrieveStripeSubscriptionBySupabaseUserId } from "./actions/retrieve-stripe-subscription";
+export { retrieveActiveStripeSubscriptionBySupabaseUserId as retrieveStripeSubscriptionBySupabaseUserId } from "./actions/retrieve-stripe-subscription";

--- a/services/accounts/actions.ts
+++ b/services/accounts/actions.ts
@@ -1,1 +1,1 @@
-export { retrieveActiveStripeSubscriptionBySupabaseUserId as retrieveStripeSubscriptionBySupabaseUserId } from "./actions/retrieve-stripe-subscription";
+export { retrieveActiveStripeSubscriptionBySupabaseUserId } from "./actions/retrieve-stripe-subscription";

--- a/services/accounts/actions/retrieve-stripe-subscription.ts
+++ b/services/accounts/actions/retrieve-stripe-subscription.ts
@@ -9,9 +9,9 @@ import {
 	users,
 } from "@/drizzle";
 import { stripe } from "@/services/external/stripe";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
-export const retrieveStripeSubscriptionBySupabaseUserId = async (
+export const retrieveActiveStripeSubscriptionBySupabaseUserId = async (
 	supabaseUserId: string,
 ) => {
 	const [subscription] = await db
@@ -28,6 +28,11 @@ export const retrieveStripeSubscriptionBySupabaseUserId = async (
 			supabaseUserMappings,
 			eq(supabaseUserMappings.userDbId, users.dbId),
 		)
-		.where(eq(supabaseUserMappings.supabaseUserId, supabaseUserId));
+		.where(
+			and(
+				eq(supabaseUserMappings.supabaseUserId, supabaseUserId),
+				eq(subscriptions.status, "active"),
+			),
+		);
 	return subscription;
 };

--- a/services/accounts/actions/retrieve-stripe-subscription.ts
+++ b/services/accounts/actions/retrieve-stripe-subscription.ts
@@ -1,14 +1,12 @@
 import {
 	db,
 	organizations,
-	stripeUserMappings,
 	subscriptions,
 	supabaseUserMappings,
 	teamMemberships,
 	teams,
 	users,
 } from "@/drizzle";
-import { stripe } from "@/services/external/stripe";
 import { and, eq } from "drizzle-orm";
 
 export const retrieveActiveStripeSubscriptionBySupabaseUserId = async (


### PR DESCRIPTION
## Summary
Ensure proper handling of canceled subscriptions by checking subscription status.

## Changes

### Code
- Modified to check subscriptions only with `active` status.
- Refactored the route06 domain check for easier debugging (ideally, this should be factored out into an Environment value 🤔 ).

## TODO before merging this PR
On stripe's dashboard

- [x] `dev` on Sandbox environment: Enable receiving the `customer.subscription.updated` and `customer.subscription.deleted` event.
- [x]  Live environment: Enable receiving the `customer.subscription.updated` and `customer.subscription.deleted` event.

## Testing

### How to test in your local environment

#### Preparation
1. Add `NEXT_PUBLIC_SITE_URL="http://localhost:3000"` to .env.local (the port may vary on your environment)
2. If you use an email with the `route06.co.jp` domain, disable the skipping of the subscription check by editing the following code.
  - Using an alias is recommended: e.g., `satoshi.ebisawa+debug20241021-1@route06.co.jp`

```ts
diff --git a/lib/utils.ts b/lib/utils.ts
index 89e08f5..1c792a2 100644
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -6,6 +6,7 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export const isEmailFromRoute06 = (email: string): boolean => {
+	return false;
 	const domain = email.split("@")[1];
 	return domain ? domain.endsWith("route06.co.jp") : false;
 };
```

4. Install the Stripe CLI and log in. Follow this instruction: https://docs.stripe.com/stripe-cli
5. Activate the local webhook listener: `stripe listen --skip-verify --forward-to localhost:3000/webhooks/stripe` (the port may vary)
  - The webhook signing secret will be printed out.
6. Start server: STRIPE_WEBHOOK_SECRET=[webhook signing secret] bun dev

#### Testing steps
1. Sign in
2. Purchase a subscription.
3. Go Payment Portal through `/settings/billing`
4. Cancel the subscription.
5. You'll receive `customer.subscription.update`: You **can** use Giselle at this point because the subscription is still `active`.
6. On stripe dashboard, use [test clocks](https://docs.stripe.com/billing/testing/test-clocks) to simulate the subscription end.
  - Instructions here: https://docs.stripe.com/billing/testing/test-clocks/simulate-subscriptions
8. You'll receive a `customer.subscription.deleted` event.
9. Now, you will be required to purchase a new subscription if you access giselle.
10. Finish test clocks' simulation.
  - ⚠️ Finishing a simulation deletes all objects associated with it, including the customer and subscription, from the sandbox or test mode. It doesn’t affect live mode. https://docs.stripe.com/billing/testing/test-clocks/simulate-subscriptions

----

### How to test in preview environment

#### Preparation
- ⚠️ You need to sign up with an email that is **not** from the `route06.co.jp` domain.
- Purchase a subscription.

#### A. Easy way: Edit the Database Directly

Locate your subscription in the `subscriptions` table and Change the status to `canceled`.

#### B. Complicated way: Use stripe's [test clocks](https://docs.stripe.com/billing/testing/test-clocks) feature

Register webhook on the preview URL to receive `customer.subscription.updated` and `customer.subscription.deleted`.
(I have not done this.)

1. Go Payment Portal through `/settings/billing`
2. Cancel the subscription. (You'll receive `customer.subscription.update` event on preview environment.)
3. On stripe dashboard, use [test clocks](https://docs.stripe.com/billing/testing/test-clocks) to simulate the subscription end.
4. You'll receive a `customer.subscription.deleted` event in preview environment.
5. Now, you will be required to purchase a new subscription if you access giselle.
6. Finish test clocks' simulation.
  - ⚠️ Finishing a simulation deletes all objects associated with it, including the customer and subscription, from the sandbox or test mode. It doesn’t affect live mode. https://docs.stripe.com/billing/testing/test-clocks/simulate-subscriptions

----

## Other Information

- [The Subscription Object](https://docs.stripe.com/api/subscriptions/object)
- [Subscription webhook events](https://docs.stripe.com/billing/subscriptions/webhooks#events)
- https://docs.stripe.com/webhooks
