### PR TITLE
Indicate the Final Node

### DIFF
--- a/app/(playground)/p/[agentId]/beta-proto/giselle-node/components.tsx
+++ b/app/(playground)/p/[agentId]/beta-proto/giselle-node/components.tsx
@@ -132,7 +132,8 @@ export function GiselleNode(props: GiselleNodeProps) {
 				)}
 			/>
 			{props.object === "node" && (
-				<div className="absolute text-black-30 font-rosart text-[12px] -translate-y-full left-[8px] -top-[2px]">
+				<div className="absolute text-black-30 font-rosart text-[12px] -translate-y-full left-[8px] -top-[2px] flex items-center gap-[12px]">
+					{props.isFinal && <span>Final</span>}
 					{props.name}
 				</div>
 			)}
@@ -214,6 +215,7 @@ export function GiselleNode(props: GiselleNodeProps) {
 						<div>outgoing: {props.outgoingConnections?.length ?? 0}</div>
 						<div>property: {JSON.stringify(props.properties, null, 2)}</div>
 						<div>ui: {JSON.stringify(props.ui, null, 2)}</div>
+						<div>isFinal: {JSON.stringify(props.isFinal)}</div>
 					</div>
 				</div>
 			)}

--- a/app/(playground)/p/[agentId]/beta-proto/giselle-node/types.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/giselle-node/types.ts
@@ -64,6 +64,7 @@ export type GiselleNode = {
 	resultPortLabel: string;
 	properties: Record<string, unknown>;
 	output: unknown;
+	isFinal: boolean;
 };
 
 export type GiselleNodeArtifactElement = {

--- a/app/(playground)/p/[agentId]/beta-proto/graph/actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/graph/actions.ts
@@ -56,6 +56,7 @@ import {
 	parseFile,
 	uploadFile,
 } from "./server-actions";
+import { type V2NodeAction, updateNode } from "./v2/node";
 
 export type AddNodeAction = {
 	type: "addNode";
@@ -68,6 +69,7 @@ type AddNodeArgs = {
 	node: GiselleNodeBlueprint;
 	position: XYPosition;
 	name: string;
+	isFinal?: boolean;
 	properties?: Record<string, unknown>;
 };
 
@@ -92,6 +94,7 @@ export const addNode = (args: AddNodeArgs): AddNodeAction => {
 				ui: { position: args.position },
 				properties: args.properties ?? {},
 				state: giselleNodeState.idle,
+				isFinal: args.isFinal ?? false,
 				output: "",
 			},
 		},
@@ -168,6 +171,8 @@ export const addNodesAndConnect = (
 	args: AddNodesAndConnectArgs,
 ): ThunkAction => {
 	return (dispatch, getState) => {
+		const state = getState();
+		const hasFinalNode = state.graph.nodes.some((node) => node.isFinal);
 		const currentNodes = getState().graph.nodes;
 		const addSourceNode = addNode({
 			...args.sourceNode,
@@ -176,6 +181,7 @@ export const addNodesAndConnect = (
 		dispatch(addSourceNode);
 		const addTargetNode = addNode({
 			...args.targetNode,
+			isFinal: !hasFinalNode,
 			name: `Untitled node - ${currentNodes.length + 2}`,
 		});
 		dispatch(addTargetNode);
@@ -810,18 +816,20 @@ export function addSourceToPromptNode(
 ): ThunkAction {
 	return async (dispatch, getState) => {
 		const state = getState();
-		const updateNode = state.graph.nodes.find(
+		const targetPromptNode = state.graph.nodes.find(
 			(node) => node.id === args.promptNode.id,
 		);
-		if (updateNode === undefined) {
+		if (targetPromptNode === undefined) {
 			return;
 		}
-		if (updateNode.archetype !== giselleNodeArchetypes.prompt) {
+		if (targetPromptNode.archetype !== giselleNodeArchetypes.prompt) {
 			return;
 		}
-		const currentSources = updateNode.properties.sources ?? [];
+		const currentSources = targetPromptNode.properties.sources ?? [];
 		if (!Array.isArray(currentSources)) {
-			throw new Error(`${updateNode.id}'s sources property is not an array`);
+			throw new Error(
+				`${targetPromptNode.id}'s sources property is not an array`,
+			);
 		}
 		dispatch(
 			updateNodeProperty({
@@ -885,6 +893,28 @@ export function addSourceToPromptNode(
 						},
 					}),
 				);
+
+				const artifactGeneratorNode = state.graph.nodes.find(
+					(node) => node.id === artifact?.generatorNode.id,
+				);
+				if (artifactGeneratorNode?.isFinal) {
+					dispatch(
+						updateNode({
+							input: {
+								id: artifact.generatorNode.id,
+								isFinal: false,
+							},
+						}),
+					);
+					dispatch(
+						updateNode({
+							input: {
+								id: outgoingNode.id,
+								isFinal: true,
+							},
+						}),
+					);
+				}
 			}
 		} else if (args.source.object === "file") {
 			if (args.source.status === fileStatuses.uploading) {
@@ -986,6 +1016,27 @@ export function addSourceToPromptNode(
 						},
 					}),
 				);
+				const webSearchGeneratorNode = state.graph.nodes.find(
+					(node) => node.id === webSearch.generatorNode.id,
+				);
+				if (webSearchGeneratorNode?.isFinal) {
+					dispatch(
+						updateNode({
+							input: {
+								id: webSearchGeneratorNode.id,
+								isFinal: false,
+							},
+						}),
+					);
+					dispatch(
+						updateNode({
+							input: {
+								id: outgoingNode.id,
+								isFinal: true,
+							},
+						}),
+					);
+				}
 			}
 		}
 	};
@@ -1253,4 +1304,5 @@ export type GraphAction =
 	| RemoveArtifactAction
 	| AddParameterToNodeAction
 	| RemoveParameterFromNodeAction
-	| UpsertWebSearchAction;
+	| UpsertWebSearchAction
+	| V2NodeAction;

--- a/app/(playground)/p/[agentId]/beta-proto/graph/actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/graph/actions.ts
@@ -1128,6 +1128,24 @@ export function removeSourceFromPromptNode(
 						},
 					}),
 				);
+				if (outgoingNode?.isFinal) {
+					dispatch(
+						updateNode({
+							input: {
+								id: outgoingNode.id,
+								isFinal: false,
+							},
+						}),
+					);
+					dispatch(
+						updateNode({
+							input: {
+								id: artifact.generatorNode.id,
+								isFinal: true,
+							},
+						}),
+					);
+				}
 			}
 		} else if (args.source.object === "webSearch") {
 			const artifact = state.graph.artifacts.find(
@@ -1172,6 +1190,24 @@ export function removeSourceFromPromptNode(
 						},
 					}),
 				);
+				if (outgoingNode?.isFinal) {
+					dispatch(
+						updateNode({
+							input: {
+								id: outgoingNode.id,
+								isFinal: false,
+							},
+						}),
+					);
+					dispatch(
+						updateNode({
+							input: {
+								id: artifact.generatorNode.id,
+								isFinal: true,
+							},
+						}),
+					);
+				}
 			}
 		}
 	};

--- a/app/(playground)/p/[agentId]/beta-proto/graph/actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/graph/actions.ts
@@ -1148,10 +1148,10 @@ export function removeSourceFromPromptNode(
 				}
 			}
 		} else if (args.source.object === "webSearch") {
-			const artifact = state.graph.artifacts.find(
-				(artifact) => artifact.id === args.source.id,
+			const webSearch = state.graph.webSearches.find(
+				(webSearch) => webSearch.id === args.source.id,
 			);
-			if (artifact === undefined) {
+			if (webSearch === undefined) {
 				return;
 			}
 			const outgoingConnectors = state.graph.connectors.filter(
@@ -1168,7 +1168,7 @@ export function removeSourceFromPromptNode(
 					state.graph.connectors.find(
 						(connector) =>
 							connector.target === outgoingNode.id &&
-							connector.source === artifact.generatorNode.id,
+							connector.source === webSearch.generatorNode.id,
 					);
 				if (artifactCreatorNodeToOutgoingNodeConnector === undefined) {
 					continue;
@@ -1202,7 +1202,7 @@ export function removeSourceFromPromptNode(
 					dispatch(
 						updateNode({
 							input: {
-								id: artifact.generatorNode.id,
+								id: webSearch.generatorNode.id,
 								isFinal: true,
 							},
 						}),

--- a/app/(playground)/p/[agentId]/beta-proto/graph/reducer.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/graph/reducer.ts
@@ -1,10 +1,20 @@
 import type { GraphAction } from "./actions";
 import type { GraphState } from "./types";
+import { isV2NodeAction, v2NodeReducer } from "./v2/node";
 
 export const graphReducer = (
 	state: GraphState,
 	action: GraphAction,
 ): GraphState => {
+	if (isV2NodeAction(action)) {
+		return {
+			...state,
+			graph: {
+				...state.graph,
+				nodes: v2NodeReducer(state.graph.nodes, action),
+			},
+		};
+	}
 	switch (action.type) {
 		case "addNode":
 			return {

--- a/app/(playground)/p/[agentId]/beta-proto/graph/v2/node.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/graph/v2/node.ts
@@ -1,0 +1,49 @@
+import type { GiselleNode, GiselleNodeId } from "../../giselle-node/types";
+
+const v2NodeActionTypes = {
+	updateNode: "v2.updateNode",
+} as const;
+type V2NodeActionType =
+	(typeof v2NodeActionTypes)[keyof typeof v2NodeActionTypes];
+export function isV2NodeAction(action: unknown): action is V2NodeAction {
+	return Object.values(v2NodeActionTypes).includes(
+		(action as V2NodeAction).type,
+	);
+}
+interface UpdateNodeAction {
+	type: Extract<V2NodeActionType, "v2.updateNode">;
+	input: UpdateNodeInput;
+}
+interface UpdateNodeInput {
+	id: GiselleNodeId;
+	isFinal?: boolean;
+}
+export function updateNode({
+	input,
+}: { input: UpdateNodeInput }): UpdateNodeAction {
+	return {
+		type: v2NodeActionTypes.updateNode,
+		input,
+	};
+}
+
+export type V2NodeAction = UpdateNodeAction;
+
+export function v2NodeReducer(
+	nodes: GiselleNode[],
+	action: V2NodeAction,
+): GiselleNode[] {
+	switch (action.type) {
+		case v2NodeActionTypes.updateNode:
+			return nodes.map((node) => {
+				if (node.id === action.input.id) {
+					return {
+						...node,
+						isFinal: action.input.isFinal ?? false,
+					};
+				}
+				return node;
+			});
+	}
+	return nodes;
+}

--- a/scripts/20241022-db-patch-node-is-final.ts
+++ b/scripts/20241022-db-patch-node-is-final.ts
@@ -1,0 +1,43 @@
+import { agents, db } from "@/drizzle";
+import { eq } from "drizzle-orm";
+
+function chunkArray<T>(array: T[], chunkSize: number): T[][] {
+	const chunks: T[][] = [];
+	for (let i = 0; i < array.length; i += chunkSize) {
+		chunks.push(array.slice(i, i + chunkSize));
+	}
+	return chunks;
+}
+
+console.log("Add 'isFinal' to the all of the nodes...");
+const listOfAgents = await db
+	.select()
+	.from(agents)
+	.where(eq(agents.id, "agnt_a23elgoizppud3e8bygx39ea"));
+console.log(`Updating ${listOfAgents.length} agents...`);
+
+const agentChunks = chunkArray(listOfAgents, 10);
+
+for (let i = 0; i < agentChunks.length; i++) {
+	const chunk = agentChunks[i];
+	console.log(
+		`  ├ Processing chunk ${i + 1}/${agentChunks.length} (${chunk.length} agents)`,
+	);
+
+	await Promise.all(
+		chunk.map(async (agent) => {
+			await db.update(agents).set({
+				graphv2: {
+					...agent.graphv2,
+					nodes: agent.graphv2.nodes.map((node) => ({
+						...node,
+						isFinal: false,
+					})),
+				},
+			});
+		}),
+	);
+
+	console.log(`  │ └ Completed chunk ${i + 1}/${i + 1}`);
+}
+console.log("All agents have been updated!");


### PR DESCRIPTION
This pull request introduces the concept of a "final node" to the GiselleNode components and related actions in the graph. The changes include updates to the node properties, actions, and reducers to handle the new `isFinal` property and ensure proper state management.

### Updates to GiselleNode components:

* Added a visual indicator for final nodes in the `GiselleNode` component. (`app/(playground)/p/[agentId]/beta-proto/giselle-node/components.tsx`) ([app/(playground)/p/[agentId]/beta-proto/giselle-node/components.tsxL135-R136](diffhunk://#diff-467e1524736fce9989c16e1a78f52403e8022fbe2161bd8988d4443a7f2318ccL135-R136), [app/(playground)/p/[agentId]/beta-proto/giselle-node/components.tsxR218](diffhunk://#diff-467e1524736fce9989c16e1a78f52403e8022fbe2161bd8988d4443a7f2318ccR218))
* Updated the `GiselleNode` type to include the `isFinal` property. (`app/(playground)/p/[agentId]/beta-proto/giselle-node/types.ts`) ([app/(playground)/p/[agentId]/beta-proto/giselle-node/types.tsR67](diffhunk://#diff-fa2e8695117c45f9dfbdd6c1619569ff0362512f762a9e1286dd3b3df7c1f435R67))

### Graph actions and reducers:

* Modified the `addNode` and `addNodesAndConnect` actions to handle the `isFinal` property. (`app/(playground)/p/[agentId]/beta-proto/graph/actions.ts`) ([app/(playground)/p/[agentId]/beta-proto/graph/actions.tsR59](diffhunk://#diff-2784109abecd25c2baa6d2b1b34c26119d8905c6c6c333cfdec069eabc01b79cR59), [app/(playground)/p/[agentId]/beta-proto/graph/actions.tsR72](diffhunk://#diff-2784109abecd25c2baa6d2b1b34c26119d8905c6c6c333cfdec069eabc01b79cR72), [app/(playground)/p/[agentId]/beta-proto/graph/actions.tsR97](diffhunk://#diff-2784109abecd25c2baa6d2b1b34c26119d8905c6c6c333cfdec069eabc01b79cR97), [app/(playground)/p/[agentId]/beta-proto/graph/actions.tsR174-R175](diffhunk://#diff-2784109abecd25c2baa6d2b1b34c26119d8905c6c6c333cfdec069eabc01b79cR174-R175), [app/(playground)/p/[agentId]/beta-proto/graph/actions.tsR184](diffhunk://#diff-2784109abecd25c2baa6d2b1b34c26119d8905c6c6c333cfdec069eabc01b79cR184))
* Updated the `addSourceToPromptNode` and `removeSourceFromPromptNode` actions to manage the state of final nodes. (`app/(playground)/p/[agentId]/beta-proto/graph/actions.ts`) ([app/(playground)/p/[agentId]/beta-proto/graph/actions.tsL813-R832](diffhunk://#diff-2784109abecd25c2baa6d2b1b34c26119d8905c6c6c333cfdec069eabc01b79cL813-R832), [app/(playground)/p/[agentId]/beta-proto/graph/actions.tsR896-R917](diffhunk://#diff-2784109abecd25c2baa6d2b1b34c26119d8905c6c6c333cfdec069eabc01b79cR896-R917), [app/(playground)/p/[agentId]/beta-proto/graph/actions.tsR1019-R1039](diffhunk://#diff-2784109abecd25c2baa6d2b1b34c26119d8905c6c6c333cfdec069eabc01b79cR1019-R1039), [app/(playground)/p/[agentId]/beta-proto/graph/actions.tsR1131-R1154](diffhunk://#diff-2784109abecd25c2baa6d2b1b34c26119d8905c6c6c333cfdec069eabc01b79cR1131-R1154), [app/(playground)/p/[agentId]/beta-proto/graph/actions.tsL1102-R1171](diffhunk://#diff-2784109abecd25c2baa6d2b1b34c26119d8905c6c6c333cfdec069eabc01b79cL1102-R1171), [app/(playground)/p/[agentId]/beta-proto/graph/actions.tsR1193-R1210](diffhunk://#diff-2784109abecd25c2baa6d2b1b34c26119d8905c6c6c333cfdec069eabc01b79cR1193-R1210))
* Integrated a new V2 node action and reducer to handle updates to the `isFinal` property. (`app/(playground)/p/[agentId]/beta-proto/graph/actions.ts`, `app/(playground)/p/[agentId]/beta-proto/graph/reducer.ts`, `app/(playground)/p/[agentId]/beta-proto/graph/v2/node.ts`) ([app/(playground)/p/[agentId]/beta-proto/graph/actions.tsL1256-R1344](diffhunk://#diff-2784109abecd25c2baa6d2b1b34c26119d8905c6c6c333cfdec069eabc01b79cL1256-R1344), [app/(playground)/p/[agentId]/beta-proto/graph/reducer.tsR3-R17](diffhunk://#diff-6eb17a4767e3d461dba850c4e45c6885cd1bf909f297845e85f46b0c66ae565eR3-R17), [app/(playground)/p/[agentId]/beta-proto/graph/v2/node.tsR1-R49](diffhunk://#diff-4c64c8fb1704dbc96d7b0d70b72e9f7dce742a7ceca8415f099dba04231d4db3R1-R49))

### Database migration:

* Added a script to update existing nodes in the database to include the `isFinal` property. (`scripts/20241022-db-patch-node-is-final.ts`)

> [!NOTE]
> The previous scripts lacked details logging, making it difficult to track their execution progress.
> The new script outputs details logs, allowing you to clearly monitor the execution status!
> ```sh
> ❯ bun scripts/20241022-db-patch-node-is-final.ts
> Add 'isFinal' to the all of the nodes...
> Updating 90 agents...
>   ├ Processing chunk 1/9 (10 agents)
>   │ └ Completed chunk 1/1
>   ├ Processing chunk 2/9 (10 agents)
>   │ └ Completed chunk 2/2
>   ├ Processing chunk 3/9 (10 agents)
>   │ └ Completed chunk 3/3
>   ├ Processing chunk 4/9 (10 agents)
>   │ └ Completed chunk 4/4
>   ├ Processing chunk 5/9 (10 agents)
>   │ └ Completed chunk 5/5
>   ├ Processing chunk 6/9 (10 agents)
>   │ └ Completed chunk 6/6
>   ├ Processing chunk 7/9 (10 agents)
>   │ └ Completed chunk 7/7
>   ├ Processing chunk 8/9 (10 agents)
>   │ └ Completed chunk 8/8
>   ├ Processing chunk 9/9 (10 agents)
>   │ └ Completed chunk 9/9
> All agents have been updated!


### Release Flow:

Since this includes database migrations, please merge and run the script after approval.