### PR TITLE
Enable local font downloads when meeting the required conditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,4 @@ next-env.d.ts
 .env.sentry-build-plugin
 
 # prepare fonts programmatically
-app/fonts/index.ts
+app/fonts/

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.1.0",
 	"private": true,
 	"scripts": {
-		"predev": "node prepare-font.js",
+		"predev": "bun prepare-font.js",
 		"dev": "SENTRY_SUPPRESS_TURBOPACK_WARNING=1 next dev --turbo",
 		"prebuild": "node prepare-font.js",
 		"build": "next build",

--- a/prepare-font.js
+++ b/prepare-font.js
@@ -21,8 +21,10 @@ const downloadFile = async (url, destination) => {
 
 (async () => {
 	if (
-		process.env.NODE_ENV === "production" &&
-		process.env.VERCEL_ENV === "production"
+		// Check if the environment is production or force downloading fonts
+		(process.env.NODE_ENV === "production" &&
+			process.env.VERCEL_ENV === "production") ||
+		process.env.FORCE_DOWNLOAD_FONTS
 	) {
 		const BLOB_URL = process.env.BLOB_URL;
 


### PR DESCRIPTION
This pull request includes changes to the `package.json` and `prepare-font.js` files to improve the development process and add flexibility to the font preparation script.

### Development Process Improvements:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L6-R6): Changed the `predev` script to use `bun` instead of `node` for preparing fonts. (`[package.jsonL6-R6](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L6-R6)`)

### Flexibility Enhancements:

* [`prepare-font.js`](diffhunk://#diff-96a3c889ac24f976a2414d7a3ea85f33e7d6ebc4096881e3b1038b159453c91bL24-R27): Added a condition to force downloading fonts by checking the `FORCE_DOWNLOAD_FONTS` environment variable. (`[prepare-font.jsL24-R27](diffhunk://#diff-96a3c889ac24f976a2414d7a3ea85f33e7d6ebc4096881e3b1038b159453c91bL24-R27)`)

### Release flow:

The database migration does not exist in these changes. So I'll release it and check it after approval.