### PR TITLE
set model to gpt-4o

### DIFF
--- a/app/(playground)/p/[agentId]/beta-proto/graph/server-actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/graph/server-actions.ts
@@ -33,7 +33,7 @@ export async function generateArtifactStream(
 	const stream = createStreamableValue();
 
 	(async () => {
-		const model = "gpt-4o-mini";
+		const model = "gpt-4o";
 		const generation = trace.generation({
 			input: params.userPrompt,
 			model,

--- a/app/(playground)/p/[agentId]/beta-proto/web-search/server-action.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/web-search/server-action.ts
@@ -35,7 +35,7 @@ export async function generateWebSearchStream(
 	const stream = createStreamableValue();
 
 	(async () => {
-		const model = "gpt-4o-mini";
+		const model = "gpt-4o";
 		const generation = trace.generation({
 			input: inputs.userPrompt,
 			model,


### PR DESCRIPTION
This pull request includes updates to the model used in two server action functions to ensure consistency across the application.

Model updates:

* `app/(playground)/p/[agentId]/beta-proto/graph/server-actions.ts`: Changed the model from `"gpt-4o-mini"` to `"gpt-4o"` in the `generateArtifactStream` function. ([app/(playground)/p/[agentId]/beta-proto/graph/server-actions.tsL36-R36](diffhunk://#diff-e2a8774e9c81bd5954bfba01727c3405a34cf0c380840dea49b8bc2e56793705L36-R36))
* `app/(playground)/p/[agentId]/beta-proto/web-search/server-action.ts`: Changed the model from `"gpt-4o-mini"` to `"gpt-4o"` in the `generateWebSearchStream` function. ([app/(playground)/p/[agentId]/beta-proto/web-search/server-action.tsL38-R38](diffhunk://#diff-3f5b189be09dfeb1c3b6da8946f60c28e2ab3d5ab9fddafb0e88a9cd63f10a91L38-R38))