### PR TITLE
Avoid error on "verify-email" page under browser auto-translation

### DIFF
--- a/app/(auth)/signup/verify-email/verify-email-form.tsx
+++ b/app/(auth)/signup/verify-email/verify-email-form.tsx
@@ -71,7 +71,7 @@ export const VerifyEmailForm: FC = () => {
 						data-1p-ignore
 						name="token"
 						onComplete={handleComplete}
-						className="notranslate"
+						className="notranslate" // prevent Google Chrome translation to avoid DOM error
 					>
 						<InputOTPGroup>
 							<InputOTPSlot index={0} />

--- a/app/(auth)/signup/verify-email/verify-email-form.tsx
+++ b/app/(auth)/signup/verify-email/verify-email-form.tsx
@@ -71,6 +71,7 @@ export const VerifyEmailForm: FC = () => {
 						data-1p-ignore
 						name="token"
 						onComplete={handleComplete}
+						className="notranslate"
 					>
 						<InputOTPGroup>
 							<InputOTPSlot index={0} />


### PR DESCRIPTION
## Summary

Enable signing up in environment with browser auto-translation by preventing unintended change in element class of OTP field

## Related Issue

- this PR resolves #41

## Changes

Disallow translation on OTP "field" on /signup/verify-email

- User experience is not affected because translation is still available for `/signup/verify-email` "page"
![image](https://github.com/user-attachments/assets/99253df2-52f6-4584-b4be-9137349037cc)


## Testing

<!-- Briefly describe the testing steps or results. -->
- `bun run dev` on local
- enable Japanese translation on browser 
- confirm that pressing backspace key produces no error on /signup/verify-email page

## Other Information

