### PR TITLE
Refactor: Replace `ThunkAction` with `CompositeAction` and Enhance State Management in `GraphProvider`

### DIFF
--- a/app/(playground)/p/[agentId]/beta-proto/flow/composite-actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/flow/composite-actions.ts
@@ -1,5 +1,5 @@
 import type { GiselleNode } from "../giselle-node/types";
-import type { ThunkAction } from "../graph/context";
+import type { CompositeAction } from "../graph/context";
 import { playgroundModes } from "../graph/types";
 import { updateMode } from "../graph/v2/mode";
 import { setFlow } from "./action";
@@ -7,7 +7,7 @@ import { runAction } from "./server-action";
 import { flowStatuses } from "./types";
 import { createFlowActionId, createFlowId, resolveActionLayers } from "./utils";
 
-export function runFlow(finalNode: GiselleNode): ThunkAction {
+export function runFlow(finalNode: GiselleNode): CompositeAction {
 	return async (dispatch, getState) => {
 		const state = getState();
 		dispatch(

--- a/app/(playground)/p/[agentId]/beta-proto/giselle-node/components/panel/prompt.tsx
+++ b/app/(playground)/p/[agentId]/beta-proto/giselle-node/components/panel/prompt.tsx
@@ -23,7 +23,7 @@ import {
 	updateNodeProperty,
 	updateNodesUI,
 } from "../../../graph/actions";
-import { type ThunkAction, useGraph } from "../../../graph/context";
+import { type CompositeAction, useGraph } from "../../../graph/context";
 import type {
 	TextContent,
 	TextContentReference,
@@ -44,7 +44,7 @@ import { Block } from "./block";
 function setTextToPropertyAndOutput(
 	nodeId: GiselleNodeId,
 	text: string,
-): ThunkAction {
+): CompositeAction {
 	return (dispatch) => {
 		dispatch(
 			updateNodeProperty({

--- a/app/(playground)/p/[agentId]/beta-proto/graph/actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/graph/actions.ts
@@ -51,7 +51,7 @@ import {
 	webSearchItemStatus,
 	webSearchStatus,
 } from "../web-search/types";
-import type { ThunkAction } from "./context";
+import type { CompositeAction } from "./context";
 import {
 	generateArtifactStream,
 	parseFile,
@@ -171,7 +171,7 @@ type AddNodesAndConnectArgs = {
 };
 export const addNodesAndConnect = (
 	args: AddNodesAndConnectArgs,
-): ThunkAction => {
+): CompositeAction => {
 	return (dispatch, getState) => {
 		const state = getState();
 		const hasFinalNode = state.graph.nodes.some((node) => node.isFinal);
@@ -268,7 +268,7 @@ export const selectNodeAndSetPanelTab = (args: {
 		id: GiselleNodeId;
 		panelTab: PanelTab;
 	};
-}): ThunkAction => {
+}): CompositeAction => {
 	return (dispatch) => {
 		dispatch(
 			selectNode({
@@ -469,7 +469,7 @@ export const removeArtifact = (
 };
 
 export const generateText =
-	(args: GenerateTextArgs): ThunkAction =>
+	(args: GenerateTextArgs): CompositeAction =>
 	async (dispatch, getState) => {
 		dispatch(
 			setNodeOutput({
@@ -815,7 +815,7 @@ type AddSourceToPromptNodeArgs = {
 };
 export function addSourceToPromptNode(
 	args: AddSourceToPromptNodeArgs,
-): ThunkAction {
+): CompositeAction {
 	return async (dispatch, getState) => {
 		const state = getState();
 		const targetPromptNode = state.graph.nodes.find(
@@ -1053,7 +1053,7 @@ type RemoveSourceFromPromptNodeArgs = {
 };
 export function removeSourceFromPromptNode(
 	args: RemoveSourceFromPromptNodeArgs,
-): ThunkAction {
+): CompositeAction {
 	return (dispatch, getState) => {
 		const state = getState();
 		const targetNode = state.graph.nodes.find(
@@ -1233,7 +1233,7 @@ export function removeNode(args: RemoveNodeArgs): RemoveNodeAction {
 	};
 }
 
-export function removeSelectedNodesOrFeedback(): ThunkAction {
+export function removeSelectedNodesOrFeedback(): CompositeAction {
 	return (dispatch, getState) => {
 		const state = getState();
 		const selectedNodes = state.graph.nodes.filter((node) => node.ui.selected);

--- a/app/(playground)/p/[agentId]/beta-proto/graph/context.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/graph/context.ts
@@ -2,11 +2,11 @@ import { createContext, useContext } from "react";
 import type { GraphAction } from "./actions";
 import type { GraphState } from "./types";
 
-export type ThunkAction = (
+export type CompositeAction = (
 	dispatch: EnhancedDispatch,
 	getState: () => GraphState,
 ) => void | Promise<void>;
-export type EnhancedDispatch = (action: GraphAction | ThunkAction) => void;
+export type EnhancedDispatch = (action: GraphAction | CompositeAction) => void;
 export type GraphContext = {
 	state: GraphState;
 	dispatch: EnhancedDispatch;

--- a/app/(playground)/p/[agentId]/beta-proto/graph/provider.tsx
+++ b/app/(playground)/p/[agentId]/beta-proto/graph/provider.tsx
@@ -31,33 +31,37 @@ export const GraphProvider: FC<PropsWithChildren<GraphProviderProps>> = ({
 	agentId,
 	defaultGraph,
 }) => {
-	const [state, originalDispatch] = useReducer(graphReducer, {
+	const [originalState, originalDispatch] = useReducer(graphReducer, {
 		graph: defaultGraph,
 	});
 	const isInitialMount = useRef(true);
+	const stateRef = useRef(originalState);
+
+	useEffect(() => {
+		stateRef.current = originalState;
+	}, [originalState]);
 
 	const deboucedSetGraphToDb = useDebounce(async (graph: Graph) => {
 		setGraphToDb(agentId, graph);
 	}, 500);
-	const enhancedDispatch: EnhancedDispatch = useCallback(
-		async (action) => {
-			if (typeof action === "function") {
-				await action(enhancedDispatch, () => state);
-			} else {
-				originalDispatch(action);
-			}
-		},
-		[state],
-	);
+	const enhancedDispatch: EnhancedDispatch = useCallback(async (action) => {
+		if (typeof action === "function") {
+			await action(enhancedDispatch, () => stateRef.current);
+		} else {
+			originalDispatch(action);
+		}
+	}, []);
 	useEffect(() => {
 		if (isInitialMount.current) {
 			isInitialMount.current = false;
 		} else {
-			deboucedSetGraphToDb(state.graph);
+			deboucedSetGraphToDb(originalState.graph);
 		}
-	}, [state, deboucedSetGraphToDb]);
+	}, [originalState, deboucedSetGraphToDb]);
 	return (
-		<GraphContext.Provider value={{ state, dispatch: enhancedDispatch }}>
+		<GraphContext.Provider
+			value={{ state: originalState, dispatch: enhancedDispatch }}
+		>
 			{children}
 		</GraphContext.Provider>
 	);


### PR DESCRIPTION
This pull request includes several changes to replace the `ThunkAction` type with `CompositeAction` across various files in the `app/(playground)/p/[agentId]/beta-proto` directory. Additionally, there are updates to the `GraphProvider` component to improve state management.

### Type Replacement:
* `app/(playground)/p/[agentId]/beta-proto/flow/composite-actions.ts`: Changed the type of `runFlow` function from `ThunkAction` to `CompositeAction`. ([app/(playground)/p/[agentId]/beta-proto/flow/composite-actions.tsL2-R10](diffhunk://#diff-20d9584da2d54a3aa33b1c809934293abf3a79d1ff79b24193478628bd8c8278L2-R10))
* `app/(playground)/p/[agentId]/beta-proto/giselle-node/components/panel/prompt.tsx`: Updated imports and function types from `ThunkAction` to `CompositeAction`. ([app/(playground)/p/[agentId]/beta-proto/giselle-node/components/panel/prompt.tsxL26-R26](diffhunk://#diff-844c954835dacbf7caf0b5f8140a358cfbd7e9d7e599ac04a550f44f0394d31bL26-R26), [app/(playground)/p/[agentId]/beta-proto/giselle-node/components/panel/prompt.tsxL47-R47](diffhunk://#diff-844c954835dacbf7caf0b5f8140a358cfbd7e9d7e599ac04a550f44f0394d31bL47-R47))
* `app/(playground)/p/[agentId]/beta-proto/graph/actions.ts`: Replaced multiple `ThunkAction` types with `CompositeAction` in various functions. ([app/(playground)/p/[agentId]/beta-proto/graph/actions.tsL54-R54](diffhunk://#diff-2784109abecd25c2baa6d2b1b34c26119d8905c6c6c333cfdec069eabc01b79cL54-R54), [app/(playground)/p/[agentId]/beta-proto/graph/actions.tsL174-R174](diffhunk://#diff-2784109abecd25c2baa6d2b1b34c26119d8905c6c6c333cfdec069eabc01b79cL174-R174), [app/(playground)/p/[agentId]/beta-proto/graph/actions.tsL271-R271](diffhunk://#diff-2784109abecd25c2baa6d2b1b34c26119d8905c6c6c333cfdec069eabc01b79cL271-R271), [app/(playground)/p/[agentId]/beta-proto/graph/actions.tsL472-R472](diffhunk://#diff-2784109abecd25c2baa6d2b1b34c26119d8905c6c6c333cfdec069eabc01b79cL472-R472), [app/(playground)/p/[agentId]/beta-proto/graph/actions.tsL818-R818](diffhunk://#diff-2784109abecd25c2baa6d2b1b34c26119d8905c6c6c333cfdec069eabc01b79cL818-R818), [app/(playground)/p/[agentId]/beta-proto/graph/actions.tsL1056-R1056](diffhunk://#diff-2784109abecd25c2baa6d2b1b34c26119d8905c6c6c333cfdec069eabc01b79cL1056-R1056), [app/(playground)/p/[agentId]/beta-proto/graph/actions.tsL1236-R1236](diffhunk://#diff-2784109abecd25c2baa6d2b1b34c26119d8905c6c6c333cfdec069eabc01b79cL1236-R1236))
* `app/(playground)/p/[agentId]/beta-proto/graph/context.ts`: Changed `ThunkAction` type definition to `CompositeAction`. ([app/(playground)/p/[agentId]/beta-proto/graph/context.tsL5-R9](diffhunk://#diff-edbfbfd190c9f358c602f0dfd637b53ae87dc2dadc2e162467f7269dea1779adL5-R9))

### State Management Improvement:
* `app/(playground)/p/[agentId]/beta-proto/graph/provider.tsx`: Enhanced state management by using a `useRef` to keep track of the current state and updated the `enhancedDispatch` function to use this ref. ([app/(playground)/p/[agentId]/beta-proto/graph/provider.tsxL34-R64](diffhunk://#diff-c2b6c6ebe87b2ac47e04053fec2fe275342a56b1e2453b5529e8a76cd5cdd28cL34-R64))