### PR TITLE
Fix license_finder job failure for PRs from a forked repository

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -5,15 +5,10 @@ on:
     branches:
       - main
   pull_request:
-  pull_request_target:
-    types: [labeled]
 
 jobs:
   license_finder:
     runs-on: ubuntu-latest
-    if: |
-      github.event.pull_request.head.repo.fork == false
-      || contains(github.event.pull_request.labels.*.name, 'safe to test')
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -26,10 +26,15 @@ jobs:
         with:
           app-id: ${{ vars.CI_TRIGGER_APP_ID }}
           private-key: ${{ secrets.CI_TRIGGER_APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v4
+      - name: Checkout code for non-fork PRs
+        if: steps.fork-check.outputs.is_fork != 'true'
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Checkout code for forked PRs
+        if: steps.fork-check.outputs.is_fork == 'true'
+        uses: actions/checkout@v4
       # To make the success of this job a prerequisite for merging into the main branch,
       # set a filter here instead of on: to determine whether or not to proceed to the next step.
       - name: Cache dependency files

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -16,7 +16,12 @@ jobs:
     env:
       LICENSE_REPORT: docs/packages-license.md
     steps:
-      - uses: actions/create-github-app-token@v1
+      - name: Check if running in a fork
+        id: fork-check
+        run: echo "is_fork=${{ github.event.pull_request.head.repo.fork }}" >> "$GITHUB_OUTPUT"
+      - name: Create GitHub App Token for non-fork PRs
+        uses: actions/create-github-app-token@v1
+        if: steps.fork-check.outputs.is_fork != 'true'
         id: app-token
         with:
           app-id: ${{ vars.CI_TRIGGER_APP_ID }}
@@ -24,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
       # To make the success of this job a prerequisite for merging into the main branch,
       # set a filter here instead of on: to determine whether or not to proceed to the next step.
       - name: Cache dependency files
@@ -66,12 +71,14 @@ jobs:
       # Commit the License Finder report as docs/packages-license.md
       - name: Generate license report
         if: |
-          steps.determine.outputs.files_changed == 'true'
+          steps.fork-check.outputs.is_fork != 'true'
+          && steps.determine.outputs.files_changed == 'true'
           && github.ref_name != github.event.repository.default_branch
         run: license_finder report --format=markdown | tail -n +2 > "$LICENSE_REPORT"
       - name: Commit license report and push
         if: |
-          steps.determine.outputs.files_changed == 'true'
+          steps.fork-check.outputs.is_fork != 'true'
+          && steps.determine.outputs.files_changed == 'true'
           && github.ref_name != github.event.repository.default_branch
         run: |
           git config user.name 'github-actions[bot]'

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -5,10 +5,15 @@ on:
     branches:
       - main
   pull_request:
+  pull_request_target:
+    types: [labeled]
 
 jobs:
   license_finder:
     runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.head.repo.fork == false
+      || contains(github.event.pull_request.labels.*.name, 'safe to test')
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,5 +1,13 @@
 name: License Compliance
 
+# ## Summary
+#
+# This workflow runs the license_finder CLI only when it detects an update to files related to the License Finder.
+# It also updates $LICENSE_REPORT and git commit.
+#
+# When triggered by a PR from a forked repository, $LICENSE_REPORT is not updated.
+# When triggered by a push to the default branch, $LICENSE_REPORT is not updated either.
+
 on:
   push:
     branches:

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -65,10 +65,14 @@ jobs:
 
       # Commit the License Finder report as docs/packages-license.md
       - name: Generate license report
-        if: steps.determine.outputs.files_changed == 'true' && github.ref_name != github.event.repository.default_branch
+        if: |
+          steps.determine.outputs.files_changed == 'true'
+          && github.ref_name != github.event.repository.default_branch
         run: license_finder report --format=markdown | tail -n +2 > "$LICENSE_REPORT"
       - name: Commit license report and push
-        if: steps.determine.outputs.files_changed == 'true' && github.ref_name != github.event.repository.default_branch
+        if: |
+          steps.determine.outputs.files_changed == 'true'
+          && github.ref_name != github.event.repository.default_branch
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'

--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -1,6 +1,6 @@
 # giselle
 
-As of October 24, 2024 10:30am. 926 total
+As of October 29, 2024 10:23am. 926 total
 
 ## Summary
 * 667 MIT


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->
For PRs from forked repositories, the license_finder job was failing because it could not reference repository variables and secrets.

Since the license_finder job is a required check for PR merging, there was a problem that PRs could not be merged even if they were approved.

This PR fixes the above.

## Related Issue
<!-- Mention the related issue number if applicable. -->
Nothing

## Changes
<!-- List the main changes made in this PR. -->
The license_finder job triggered by a PR from the fork repository will no longer update `$LICENSE_REPORT`.

## Testing
<!-- Briefly describe the testing steps or results. -->
PR from forked repository, license_finder job passes.✅

* https://github.com/route06inc/giselle/pull/59

## Other Information
<!-- Add any other relevant information for the reviewer. -->
Nothing
