### PR TITLE
Fix ` Error: Failed to set Next.js data cache, items over 2MB can not be cached (2865842 bytes) at IncrementalCache.set` error on development

### DIFF
--- a/app/(main)/agents/page.tsx
+++ b/app/(main)/agents/page.tsx
@@ -1,4 +1,3 @@
-import { getTeamMembershipByAgentId } from "@/app/(auth)/lib/get-team-membership-by-agent-id";
 import { getUser } from "@/lib/supabase";
 import { createAgent, getAgents } from "@/services/agents";
 import { CreateAgentButton } from "@/services/agents/components";
@@ -9,18 +8,7 @@ type AgentListProps = {
 	userId: string;
 };
 async function AgentList(props: AgentListProps) {
-	const allAgents = await getAgents({ userId: props.userId });
-	const agents = (
-		await Promise.all(
-			allAgents.map(async (agent) => {
-				const teamMembership = await getTeamMembershipByAgentId(
-					agent.id,
-					props.userId,
-				);
-				return teamMembership ? agent : null;
-			}),
-		)
-	).filter((v) => v != null);
+	const agents = await getAgents({ userId: props.userId });
 
 	return (
 		<div className="flex flex-col gap-2">


### PR DESCRIPTION
## Summary
On my local environemnt, I've noticed this warning.

```
⨯ unhandledRejection: Error: Failed to set Next.js data cache, items over 2MB can not be cached (2865842 bytes)
    at IncrementalCache.set (/Users/satoshi/dev/src/github.com/route06inc/giselle/node_modules/next/dist/server/lib/incremental-cache/index.js:358:23)
    at cacheNewResult (/Users/satoshi/dev/src/github.com/route06inc/giselle/.next/server/chunks/ssr/node_modules_37df5f._.js:25514:28)
    at cachedCb (/Users/satoshi/dev/src/github.com/route06inc/giselle/.next/server/chunks/ssr/node_modules_37df5f._.js:25667:21)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async $$RSC_SERVER_ACTION_0 (/Users/satoshi/dev/src/github.com/route06inc/giselle/.next/server/chunks/ssr/[root of the server]__f32a54._.js:714:12)
    at async AgentList (/Users/satoshi/dev/src/github.com/route06inc/giselle/.next/server/chunks/ssr/[root of the server]__f32a54._.js:907:23)
```

This PR fixes this error.


## Changes
Fetch agents only the current user can use instead of fetching all agents from database.


## Other Information
In Next.js 15,  `unstable_cache` is not recommended.
https://nextjs.org/docs/canary/app/api-reference/legacy-apis/unstable_cache
But I didn't change that caching part in this PR.
