### PR TITLE
Use next.config.ts instead of next.config.mjs

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,6 @@
 import { withSentryConfig } from "@sentry/nextjs";
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+import type { NextConfig } from "next";
+const nextConfig: NextConfig = {
 	eslint: {
 		// Warning: This allows production builds to successfully complete even if
 		// your project has ESLint errors.


### PR DESCRIPTION
Next.js 15 introduced native support for TypeScript configuration files. 
https://nextjs.org/blog/next-15#support-for-nextconfigts

Allowing us to use next.config.ts instead of next.config.mjs.
