### PR TITLE
feat: Set 5-minute timeout for Agent playground page

### DIFF
--- a/app/(playground)/p/[agentId]/page.tsx
+++ b/app/(playground)/p/[agentId]/page.tsx
@@ -20,6 +20,10 @@ import {
 } from "./beta-proto/react-flow-adapter/types";
 import type { AgentId } from "./beta-proto/types";
 
+// Extend the max duration of the server actions from this page to 5 minutes
+// https://vercel.com/docs/functions/runtimes#max-duration
+export const maxDuration = 300;
+
 function graphToReactFlow(grpah: Graph) {
 	const nodes: ReactFlowNode[] = grpah.nodes.map((node) => {
 		return {

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,0 @@
-{
-	"functions": {
-		"app/**/*": {
-			"maxDuration": 60
-		}
-	}
-}


### PR DESCRIPTION
Now that we know how to set maxDuration on a page-by-page basis, we have changed from using vercel.json to specify it for the entire project. 
https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#maxduration

Also, when executing the Run function, MaxDuration is now set to the maximum of 5 minutes, since the previous 1 minute may be too short.
