### PR TITLE
Remove `TRIGGER_SECRET_KEY` from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,10 +68,6 @@ NEXT_PUBLIC_SUPABASE_URL=
 # @see https://docs.tavily.com/docs/welcome#getting-started
 TAVILY_API_KEY=
 
-# Trigger.dev https://trigger.dev/
-# @see https://trigger.dev/docs/apikeys
-TRIGGER_SECRET_KEY=
-
 # Unstructured https://unstructured.io/
 # @see https://docs.unstructured.io/api-reference/api-services/saas-api-development-guide
 UNSTRUCTURED_API_KEY=


### PR DESCRIPTION
## Summary
I removed `TRIGGER_SECRET_KEY` from .env.example .

## Related Issue
- https://github.com/route06inc/giselle/pull/71

## Changes
Just removed `TRIGGER_SECRET_KEY` from .env.example

## Testing
Please update your environment variables and try it.

## Other Information