### PR TITLE
feat(llm): Add configurable model provider support

### DIFF
--- a/app/(playground)/p/[agentId]/beta-proto/artifact/server-actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/artifact/server-actions.ts
@@ -8,14 +8,17 @@ import { getUserSubscriptionId, isRoute06User } from "@/app/(auth)/lib";
 import { metrics } from "@opentelemetry/api";
 import { Langfuse } from "langfuse";
 import { schema as artifactSchema } from "../artifact/schema";
+import { buildLanguageModel } from "../flow/server-actions/generate-text";
 import type { SourceIndex } from "../source/types";
 import { sourceIndexesToSources, sourcesToText } from "../source/utils";
 import type { AgentId } from "../types";
+import type { ModelConfiguration } from "./types";
 
 type GenerateArtifactStreamParams = {
 	agentId: AgentId;
 	userPrompt: string;
 	sourceIndexes: SourceIndex[];
+	modelConfiguration: ModelConfiguration;
 };
 export async function generateArtifactStream(
 	params: GenerateArtifactStreamParams,
@@ -46,18 +49,18 @@ ${sourcesToText(sources)}
 	const stream = createStreamableValue();
 
 	(async () => {
-		const model = "gpt-4o";
+		const model = buildLanguageModel(params.modelConfiguration);
 		const generation = trace.generation({
 			input: params.userPrompt,
-			model,
+			model: params.modelConfiguration.modelId,
 		});
 		const { partialObjectStream, object } = await streamObject({
-			model: openai(model),
+			model,
 			system,
 			prompt: params.userPrompt,
 			schema: artifactSchema,
 			onFinish: async (result) => {
-				const meter = metrics.getMeter("OpenAI");
+				const meter = metrics.getMeter(params.modelConfiguration.provider);
 				const tokenCounter = meter.createCounter("token_consumed", {
 					description: "Number of OpenAI API tokens consumed by each request",
 				});

--- a/app/(playground)/p/[agentId]/beta-proto/artifact/types.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/artifact/types.ts
@@ -32,3 +32,11 @@ export type GeneratedObject = {
 	description: string;
 };
 export type PartialGeneratedObject = Partial<GeneratedObject>;
+
+export type ModelProvider = "openai" | "anthropic";
+export interface ModelConfiguration {
+	provider: ModelProvider;
+	modelId: string;
+	temperature: number;
+	topP: number;
+}

--- a/app/(playground)/p/[agentId]/beta-proto/artifact/utils.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/artifact/utils.ts
@@ -1,11 +1,39 @@
-function isString(value: unknown): value is string {
-	return typeof value === "string";
+import { giselleNodeArchetypes } from "../giselle-node/blueprints";
+import type { GiselleNode } from "../giselle-node/types";
+import type { ModelConfiguration, ModelProvider } from "./types";
+
+export function isModelProvider(value: unknown): value is ModelProvider {
+	return value === "openai" || value === "anthropic";
 }
 
-function isObject(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null;
-}
-
-function isBoolean(value: unknown): value is boolean {
-	return typeof value === "boolean";
+const fallbackModelConfiguration: ModelConfiguration = {
+	provider: "openai",
+	modelId: "gpt-4o",
+	temperature: 0.7,
+	topP: 0.8,
+};
+export function resolveModelConfiguration(
+	node: GiselleNode,
+): ModelConfiguration {
+	if (node.archetype !== giselleNodeArchetypes.textGenerator) {
+		return fallbackModelConfiguration;
+	}
+	if (
+		node.properties === null ||
+		typeof node.properties !== "object" ||
+		!("llm" in node.properties) ||
+		typeof node.properties.llm !== "string"
+	) {
+		return fallbackModelConfiguration;
+	}
+	const [provider, modelId] = node.properties.llm.split(":");
+	if (!isModelProvider(provider) || typeof modelId !== "string") {
+		return fallbackModelConfiguration;
+	}
+	return {
+		provider,
+		modelId,
+		temperature: 0.7,
+		topP: 0.8,
+	};
 }

--- a/app/(playground)/p/[agentId]/beta-proto/graph/actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/graph/actions.ts
@@ -3,6 +3,7 @@ import { createArtifactId } from "../artifact/factory";
 import { generateArtifactStream } from "../artifact/server-actions";
 import type { Artifact, ArtifactId } from "../artifact/types";
 import type { PartialGeneratedObject } from "../artifact/types";
+import { resolveModelConfiguration } from "../artifact/utils";
 import type { V2ConnectorAction } from "../connector/actions";
 import { createConnectorId } from "../connector/factory";
 import type { ConnectorId, ConnectorObject } from "../connector/types";
@@ -478,6 +479,7 @@ export const generateText =
 					agentId: getState().graph.agentId,
 					userPrompt: instructionNode.output as string,
 					sourceIndexes,
+					modelConfiguration: resolveModelConfiguration(node),
 				});
 				let content: PartialGeneratedObject = {};
 				for await (const streamContent of readStreamableValue(object)) {


### PR DESCRIPTION
In #77 we supports configurable model for Flow. This one also supports for Playground.

Add ModelConfiguration type and utilities to support different LLM providers (OpenAI, Anthropic) with customizable parameters like temperature and topP. Replace hardcoded GPT-4 model with dynamic model selection based on node properties.

- Introduce ModelProvider type and ModelConfiguration interface
- Add resolveModelConfiguration utility for model selection
- Update generateArtifactStream to use configurable models
- Set default fallback configuration to gpt-4o

Related to text generation workflow improvements
